### PR TITLE
docs: update documentation links to foundation hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Unified system for Warhammer 40k action notation, parsing, and game state recons
 - `warscribe.core`: Domain models and schemas (Units, Actions, Transcripts).
 - `warscribe.parser`: Logic for ingesting chat logs and reconstructing game state.
 
+## Documentation
+
+> **📌 Important:** The WARScribe notation standard and parsing logic are documented in [**vindicta-foundation**](https://github.com/vindicta-platform/vindicta-foundation/blob/main/docs/concepts/warscribe.md).
+
 ## Usage
+
 
 This package is part of the Vindicta Platform.


### PR DESCRIPTION
This PR updates reference documentation links to point to the new centralized documentation hub in the `vindicta-foundation` repository.